### PR TITLE
update send email function  variable names

### DIFF
--- a/src/utils/send-mail.js
+++ b/src/utils/send-mail.js
@@ -4,16 +4,16 @@ const { config } = require('../config');
 const sendMail = async (mailOptions) => {
   let sendMailOptions = {
     ...mailOptions,
-    from: config.MAIL_SEND_FROM,
-    sender: config.MAIL_SEND_FROM,
+    from: config.emailSendFrom,
+    sender: config.emailSendFrom,
   };
 
   var transport = nodemailer.createTransport({
     host: 'smtp.mailtrap.io',
     port: 2525,
     auth: {
-      user: config.MAIL_SEND_USERNAME,
-      pass: config.MAIL_SEND_PASSWORD,
+      user: config.mailSendUsername,
+      pass: config.mailSendPassword,
     },
   });
   try {


### PR DESCRIPTION
update the name of send mail options variable which is wrong enter be…fore in sendMail function like email_send_from instead of emailSendFrom which is getting from config

just update the variable names of send email function
consider my pull request as contribution